### PR TITLE
use bundler instead of jeweler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in epubcheck.gemspec
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,19 +1,2 @@
-require 'rubygems'
-require 'rake'
-
-begin
-  require 'jeweler'
-  Jeweler::Tasks.new do |gem|
-    gem.name = "epubcheck"
-    gem.summary = %Q{command-line ePub check tool}
-    gem.description = %Q{This is a command-line ePub check tool. It is wrapper of epubcheck(http://code.google.com/p/epubcheck/).}
-    gem.executables = ["epubcheck"]
-    gem.files = Dir['lib/**/*']
-    gem.email = "jugyo.org@gmail.com"
-    gem.homepage = "http://github.com/jugyo/epubcheck"
-    gem.authors = ["jugyo"]
-  end
-  Jeweler::GemcutterTasks.new
-rescue LoadError
-  puts "Jeweler (or a dependency) not available. Install it with: gem install jeweler"
-end
+require "bundler/gem_tasks"
+task :default => :spec

--- a/epubcheck.gemspec
+++ b/epubcheck.gemspec
@@ -42,5 +42,8 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/jugyo/epubcheck"
   s.rubygems_version = "2.2.2"
   s.summary = "command-line ePub check tool"
+
+  s.add_development_dependency "bundler", "~> 1.11"
+  s.add_development_dependency "rake", "~> 10.0"
 end
 


### PR DESCRIPTION
I cannot install epubcheck on ruby 2.3.0.  The problem is jeweler gem, so remove it and use bundler.
